### PR TITLE
Fix some issues

### DIFF
--- a/src/test/java/arsw/wherewe/back/arepalocations/ArepaLocationsApplicationTests.java
+++ b/src/test/java/arsw/wherewe/back/arepalocations/ArepaLocationsApplicationTests.java
@@ -8,6 +8,7 @@ class ArepaLocationsApplicationTests {
 
 	@Test
 	void contextLoads() {
+		// this is empty because it is not necessary
 	}
 
 }

--- a/src/test/java/arsw/wherewe/back/arepalocations/controller/LocationControllerTest.java
+++ b/src/test/java/arsw/wherewe/back/arepalocations/controller/LocationControllerTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-public class LocationControllerTest {
+class LocationControllerTest {
 
     // Constants for test data
     private static final String GROUP_ID = "group123";

--- a/src/test/java/arsw/wherewe/back/arepalocations/model/FavoritePlaceTest.java
+++ b/src/test/java/arsw/wherewe/back/arepalocations/model/FavoritePlaceTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class FavoritePlaceTest {
+class FavoritePlaceTest {
 
 
     @Test

--- a/src/test/java/arsw/wherewe/back/arepalocations/model/LocationMessageTest.java
+++ b/src/test/java/arsw/wherewe/back/arepalocations/model/LocationMessageTest.java
@@ -3,9 +3,8 @@ package arsw.wherewe.back.arepalocations.model;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LocationMessageTest {
+class LocationMessageTest {
 
     @Test
     void constructor_withParameters_initializesFields() {

--- a/src/test/java/arsw/wherewe/back/arepalocations/service/FavoritePlaceServiceTest.java
+++ b/src/test/java/arsw/wherewe/back/arepalocations/service/FavoritePlaceServiceTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-public class FavoritePlaceServiceTest {
+class FavoritePlaceServiceTest {
 
     @Mock
     private FavoritePlaceRepository favoritePlaceRepository;


### PR DESCRIPTION
This pull request involves several changes to the test classes in the `src/test/java/arsw/wherewe/back/arepalocations` directory. The primary focus is on modifying the access level of the test classes and adding a comment to an empty test method.

Changes to test class access levels:

* [`src/test/java/arsw/wherewe/back/arepalocations/controller/LocationControllerTest.java`](diffhunk://#diff-7d76253425e228c2c499a6768716fb7125c0b15206a0c617f3842c5b123d5cf2L21-R21): Changed the access level of `LocationControllerTest` from `public` to package-private.
* [`src/test/java/arsw/wherewe/back/arepalocations/model/FavoritePlaceTest.java`](diffhunk://#diff-a3548e50592adb7b86e04e664803ad0d9ee95a8399258857bdd6af4d388ca686L7-R7): Changed the access level of `FavoritePlaceTest` from `public` to package-private.
* [`src/test/java/arsw/wherewe/back/arepalocations/model/LocationMessageTest.java`](diffhunk://#diff-cdf0b4d1d0ea8d268d0433d37333b5b22eb67556fedd6bbd36f81a1b73c3c949L6-R7): Changed the access level of `LocationMessageTest` from `public` to package-private.
* [`src/test/java/arsw/wherewe/back/arepalocations/service/FavoritePlaceServiceTest.java`](diffhunk://#diff-e374cd1a0d5010d7f38c15788da9146cbf6a4dd6bb89531420e0ea48eeee324eL17-R17): Changed the access level of `FavoritePlaceServiceTest` from `public` to package-private.

Comment addition:

* [`src/test/java/arsw/wherewe/back/arepalocations/ArepaLocationsApplicationTests.java`](diffhunk://#diff-ebbd5cedc4f40805741e7bfe94426e19a21bee89448b95528a1106bbd9706333R11): Added a comment explaining why the `contextLoads` test method is empty.