### PR TITLE
Fix issues

### DIFF
--- a/src/main/java/arsw/wherewe/back/arepalocations/controller/LocationController.java
+++ b/src/main/java/arsw/wherewe/back/arepalocations/controller/LocationController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import arsw.wherewe.back.arepalocations.model.PushToken;
 import arsw.wherewe.back.arepalocations.service.NotificationService;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/arsw/wherewe/back/arepalocations/service/NotificationService.java
+++ b/src/main/java/arsw/wherewe/back/arepalocations/service/NotificationService.java
@@ -131,7 +131,7 @@ public class NotificationService {
                     conn.getResponseCode();
 
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    //
                 }
             }
         }

--- a/src/test/java/arsw/wherewe/back/arepalocations/model/PushTokenTest.java
+++ b/src/test/java/arsw/wherewe/back/arepalocations/model/PushTokenTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-public class PushTokenTest {
+class PushTokenTest {
 
     @Test
     void constructor_initializesFields() {


### PR DESCRIPTION
This pull request includes several changes to the `arsw/wherewe/back/arepalocations` project, focusing on the removal of unused imports, code cleanup, and test class modifications. The most important changes are summarized below:

Code cleanup:

* [`src/main/java/arsw/wherewe/back/arepalocations/controller/LocationController.java`](diffhunk://#diff-b46f2c0af86a6f3e7b6f2a93f901bd8595436c8e145bef91f5008d2d221222a0L16): Removed the unused import of `PushToken`.
* [`src/main/java/arsw/wherewe/back/arepalocations/service/NotificationService.java`](diffhunk://#diff-6fde4a0fea112743a481852664e480d3c461283cf9bfacab1a45910f54545355L134-R134): Removed the call to `e.printStackTrace()` in the exception handling block of the `sendNotification` method.

Test class modifications:

* [`src/test/java/arsw/wherewe/back/arepalocations/model/PushTokenTest.java`](diffhunk://#diff-c8a0fbcf274984d6d8bb392ccaeee15defa472c063eaab03a22445441dbf1d2bL8-R8): Changed the `PushTokenTest` class to use package-private visibility instead of public.