### PR TITLE
Add: deploy

### DIFF
--- a/src/main/java/arsw/wherewe/back/arepalocations/config/SecurityConfig.java
+++ b/src/main/java/arsw/wherewe/back/arepalocations/config/SecurityConfig.java
@@ -15,7 +15,6 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable()) // Deshabilitar CSRF para WebSocket
                 .authorizeHttpRequests(authorize -> authorize
                         // Permitir acceso sin autenticación a WebSocket y Swagger
                         .requestMatchers("/ws/**", "/api-locations/**", "/swagger-ui/**").permitAll()


### PR DESCRIPTION
This pull request includes a minor change to the `SecurityConfig` class. The change removes the disabling of CSRF protection for WebSocket connections, likely to enhance security.

Security configuration change:

* [`src/main/java/arsw/wherewe/back/arepalocations/config/SecurityConfig.java`](diffhunk://#diff-9669a26e41e7ee2d20f88b79715d799b16792740bfc080b73f8409c8f8409fcaL18): Removed the line disabling CSRF protection for WebSocket connections.