### PR TITLE
Fix tests

### DIFF
--- a/src/test/java/arsw/wherewe/back/arepalocations/ArepaLocationsApplicationTest.java
+++ b/src/test/java/arsw/wherewe/back/arepalocations/ArepaLocationsApplicationTest.java
@@ -5,8 +5,20 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
-@TestPropertySource(properties = {"MONGODB_URI=mongodb://localhost:27017/testdb"})
-public class ArepaLocationsApplicationTest {
+@TestPropertySource(properties = {
+        "MONGODB_URI=mongodb://localhost:27017/testdb",
+        "FIREBASE_PROJECT_ID=test-project-id",
+        "FIREBASE_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC0...fakekey...\n-----END PRIVATE KEY-----\n",
+        "FIREBASE_PRIVATE_KEY_ID=test-private-key-id",
+        "FIREBASE_CLIENT_EMAIL=test-client-email@wherewe.iam.gserviceaccount.com",
+        "FIREBASE_CLIENT_ID=1234567890",
+        "FIREBASE_AUTH_URI=https requirement://accounts.google.com/o/oauth2/auth",
+        "FIREBASE_TOKEN_URI=https://oauth2.googleapis.com/token",
+        "FIREBASE_AUTH_PROVIDER_X509_CERT_URL=https://www.googleapis.com/oauth2/v1/certs",
+        "FIREBASE_CLIENT_X509_CERT_URL=https://www.googleapis.com/robot/v1/metadata/x509/test-client-email@wherewe.iam.gserviceaccount.com",
+        "FIREBASE_UNIVERSE_DOMAIN=googleapis.com"
+})
+class ArepaLocationsApplicationTest {
 
     @Test
     void contextLoads() {


### PR DESCRIPTION
This pull request updates the test configuration for the `ArepaLocationsApplicationTest` class to include Firebase-related properties in addition to the existing MongoDB URI. This change ensures that the application's Firebase integration can be tested in a controlled environment.

### Test configuration updates:

* [`src/test/java/arsw/wherewe/back/arepalocations/ArepaLocationsApplicationTest.java`](diffhunk://#diff-a52ce032344e559703872237159259ee452284de6e5f48f437196a448e6087a3L8-R21): Added Firebase-related properties such as `FIREBASE_PROJECT_ID`, `FIREBASE_PRIVATE_KEY`, and others to the `@TestPropertySource` annotation. These properties simulate Firebase configuration for testing purposes.